### PR TITLE
Auto publish to Wally registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Build
         run: lune run build --target prod --output ${{ env.MODEL_FILE }}
 
+      - name: Login to Wally registry
+        run: wally login --token ${{ secrets.WALLY_REGISTRY_TOKEN }}
+
+      - name: Publish to Wally
+        if: ${{ github.event.release }}
+        run: wally publish
+
       - uses: softprops/action-gh-release@v1
         if: ${{ github.event.release }}
         with:


### PR DESCRIPTION
After making the most recent release I realized there isn't any logic that will automatically publish to the Wally registry. I ran `wally publish` locally just to get 0.7.0 live, so this will be for future versions