### PR TITLE
Stop spamming folks for reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @flipbook-labs/flipbook-maintainers @flipbook-labs/flipbook-contributors
+* @flipbook-labs/flipbook-maintainers


### PR DESCRIPTION
# Problem

I feel like I've been spamming folks with PR review requests, especially for Storyteller, ModuleLoader, and FlipbookBatteries where I usually just merge those after a self-review.

# Solution

Updated CODEOWNERS to remove `flipbook-contributors`. The main review group will still be included but this helps alleviate how often folks are getting pinged

Relates to: https://github.com/flipbook-labs/flipbook/issues/556
