### PR TITLE
Support client-side require in lower security contexts

### DIFF
--- a/src/compileWithLoadstring.luau
+++ b/src/compileWithLoadstring.luau
@@ -4,7 +4,12 @@ local types = require("@root/types")
 type ModuleFunction = types.ModuleFunction
 
 local function loadString(source: string, chunkName: string): (ModuleFunction?, string?)
-	local moduleFunction, errorMessage = loadstring(source, chunkName)
+	local ok, moduleFunction, errorMessage = pcall(loadstring, source, chunkName)
+
+	if not ok then
+		return nil, nil
+	end
+
 	if errorMessage then
 		errorMessage = cleanLoadstringStack(errorMessage) :: string
 	end

--- a/src/createModuleLoader.luau
+++ b/src/createModuleLoader.luau
@@ -68,6 +68,17 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 
 	local chunkName = moduleScript:GetFullName()
 
+	-- `newSource` compiles to an outer function that, when called with
+	-- (script, require, ...), returns the inner function wrapping the original
+	-- source. We call both layers so the returned ModuleFunction yields the
+	-- module's actual exports rather than the inner closure.
+	local function wrapCompiled(outerFunction: any): ModuleFunction
+		return function(...)
+			local innerFunction = outerFunction(...)
+			return innerFunction()
+		end
+	end
+
 	-- A nil chunkFn with a message means a real syntax error (surface it); a
 	-- nil chunkFn with no message means loadstring is disabled (fall through).
 	local chunkFn, syntaxErrorMessage = compileWithLoadstring(newSource, chunkName)
@@ -75,7 +86,7 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 	if chunkFn then
 		local ok, result = xpcall(chunkFn, debug.traceback)
 		if ok and typeof(result) == "function" then
-			return result :: ModuleFunction
+			return wrapCompiled(result)
 		end
 		error(result, 0)
 	end
@@ -97,7 +108,7 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 		tmpScript:Destroy()
 
 		if ok then
-			return moduleFunction
+			return wrapCompiled(moduleFunction)
 		end
 
 		error(err, 0)

--- a/src/createModuleLoader.luau
+++ b/src/createModuleLoader.luau
@@ -30,10 +30,6 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 		return requireAny(moduleScript)
 	end
 
-	local tmpScript = Instance.new("ModuleScript")
-	tmpScript.Name = moduleScript.Name
-	tmpScript.Archivable = false
-
 	local mergedParams = { "script", "require" }
 	if params then
 		for _, param in params do
@@ -94,6 +90,10 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 	if syntaxErrorMessage then
 		error(syntaxErrorMessage, 0)
 	end
+
+	local tmpScript = Instance.new("ModuleScript")
+	tmpScript.Name = moduleScript.Name
+	tmpScript.Archivable = false
 
 	if not setModuleSource(tmpScript, newSource) then
 		return nativeRequire

--- a/src/createModuleLoader.luau
+++ b/src/createModuleLoader.luau
@@ -30,6 +30,10 @@ local function wrapCompiled(outerFunction: any): ModuleFunction
 end
 
 local function getModuleFunction(moduleScript: ModuleScript, params: { string }?): ModuleFunction
+	local nativeRequire: ModuleFunction = function()
+		return requireAny(moduleScript)
+	end
+
 	local tmpScript = Instance.new("ModuleScript")
 	tmpScript.Name = moduleScript.Name
 	tmpScript.Archivable = false
@@ -47,9 +51,7 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 	-- require and skip the rest.
 	if not source then
 		tmpScript:Destroy()
-		return function()
-			return requireAny(moduleScript)
-		end
+		return nativeRequire
 	end
 
 	-- This all gets collapsed onto a single line so we retain line numbers of
@@ -99,9 +101,7 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 
 	if not setModuleSource(tmpScript, newSource) then
 		tmpScript:Destroy()
-		return function()
-			return requireAny(moduleScript)
-		end
+		return nativeRequire
 	end
 
 	local createModuleFunction

--- a/src/createModuleLoader.luau
+++ b/src/createModuleLoader.luau
@@ -180,8 +180,6 @@ function createModuleLoader(): ModuleLoader
 				-- Notice how the arguments here map to the params in
 				-- `getModuleFunction`, which in this case is `script`,
 				-- `require`, and `_G` in the context of the loaded module.
-				-- In the embedded/client flow where we fall back to native
-				-- require, moduleFunction is a wrapper that ignores these args.
 				exports = table.pack(moduleFunction(resolvedModule, childRequire, globals))
 			end, debug.traceback)
 

--- a/src/createModuleLoader.luau
+++ b/src/createModuleLoader.luau
@@ -19,24 +19,36 @@ type ModuleLoader = types.ModuleLoader
 type ModuleRegistry = types.ModuleRegistry
 type ModuleFunction = types.ModuleFunction
 
-local function getModuleFunction(moduleScript: ModuleScript, params: { string }?): ModuleFunction
-	local nativeRequire: ModuleFunction = function()
-		return requireAny(moduleScript)
+-- newSource wraps the original in two nested functions. We call both layers so
+-- the returned ModuleFunction yields the module's actual exports rather than
+-- the inner closure.
+local function wrapCompiled(outerFunction: any): ModuleFunction
+	return function(...)
+		local innerFunction = outerFunction(...)
+		return innerFunction()
 	end
+end
 
-	-- If we can't read the source there's nothing we can really do with this
-	-- module, so skip straight to native require. We mainly hit this case with
-	-- Flipbook's embedded flow that runs off the client in userspace, so our
-	-- options are slim.
-	local source = getModuleSource(moduleScript)
-	if not source then
-		return nativeRequire
-	end
+local function getModuleFunction(moduleScript: ModuleScript, params: { string }?): ModuleFunction
+	local tmpScript = Instance.new("ModuleScript")
+	tmpScript.Name = moduleScript.Name
+	tmpScript.Archivable = false
 
 	local mergedParams = { "script", "require" }
 	if params then
 		for _, param in params do
 			table.insert(mergedParams, param)
+		end
+	end
+
+	local source = getModuleSource(moduleScript)
+
+	-- If we can't read the source (e.g. client userspace), fall back to native
+	-- require and skip the rest.
+	if not source then
+		tmpScript:Destroy()
+		return function()
+			return requireAny(moduleScript)
 		end
 	end
 
@@ -66,24 +78,13 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 		"end",
 	}, " ")
 
-	local chunkName = moduleScript:GetFullName()
-
-	-- `newSource` compiles to an outer function that, when called with
-	-- (script, require, ...), returns the inner function wrapping the original
-	-- source. We call both layers so the returned ModuleFunction yields the
-	-- module's actual exports rather than the inner closure.
-	local function wrapCompiled(outerFunction: any): ModuleFunction
-		return function(...)
-			local innerFunction = outerFunction(...)
-			return innerFunction()
-		end
-	end
-
 	-- A nil chunkFn with a message means a real syntax error (surface it); a
-	-- nil chunkFn with no message means loadstring is disabled (fall through).
-	local chunkFn, syntaxErrorMessage = compileWithLoadstring(newSource, chunkName)
+	-- nil chunkFn with no message means loadstring is disabled (fall through to
+	-- tmpScript).
+	local chunkFn, syntaxErrorMessage = compileWithLoadstring(newSource, moduleScript:GetFullName())
 
 	if chunkFn then
+		tmpScript:Destroy()
 		local ok, result = xpcall(chunkFn, debug.traceback)
 		if ok and typeof(result) == "function" then
 			return wrapCompiled(result)
@@ -92,31 +93,29 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 	end
 
 	if syntaxErrorMessage then
+		tmpScript:Destroy()
 		error(syntaxErrorMessage, 0)
 	end
 
-	local tmpScript = Instance.new("ModuleScript")
-	tmpScript.Name = moduleScript.Name
-	tmpScript.Archivable = false
-
-	if setModuleSource(tmpScript, newSource) then
-		local moduleFunction
-		local ok, err = xpcall(function()
-			moduleFunction = requireAny(tmpScript)
-		end, debug.traceback)
-
+	if not setModuleSource(tmpScript, newSource) then
 		tmpScript:Destroy()
-
-		if ok then
-			return wrapCompiled(moduleFunction)
+		return function()
+			return requireAny(moduleScript)
 		end
-
-		error(err, 0)
 	end
+
+	local createModuleFunction
+	local ok, err = xpcall(function()
+		createModuleFunction = requireAny(tmpScript)
+	end, debug.traceback)
 
 	tmpScript:Destroy()
 
-	return nativeRequire
+	if not ok then
+		error(err, 0)
+	end
+
+	return wrapCompiled(createModuleFunction)
 end
 
 local function weak<K, V>(tab: { [K]: V }): { [K]: V }

--- a/src/createModuleLoader.luau
+++ b/src/createModuleLoader.luau
@@ -19,13 +19,9 @@ type ModuleLoader = types.ModuleLoader
 type ModuleRegistry = types.ModuleRegistry
 type ModuleFunction = types.ModuleFunction
 
--- newSource wraps the original in two nested functions. We call both layers so
--- the returned ModuleFunction yields the module's actual exports rather than
--- the inner closure.
-local function wrapCompiled(outerFunction: any): ModuleFunction
+local function makeModuleFunction(compiledOuter): ModuleFunction
 	return function(...)
-		local innerFunction = outerFunction(...)
-		return innerFunction()
+		return compiledOuter(...)()
 	end
 end
 
@@ -87,7 +83,10 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 	if chunkFn then
 		local ok, result = xpcall(chunkFn, debug.traceback)
 		if ok and typeof(result) == "function" then
-			return wrapCompiled(result)
+			-- I don't think there's a way to narrow this further but we know by
+			-- this point we we're getting back the newSource result so I think
+			-- this is fine
+			return makeModuleFunction(result :: any)
 		end
 		error(result, 0)
 	end
@@ -111,7 +110,7 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 		error(err, 0)
 	end
 
-	return wrapCompiled(createModuleFunction)
+	return makeModuleFunction(createModuleFunction)
 end
 
 local function weak<K, V>(tab: { [K]: V }): { [K]: V }

--- a/src/createModuleLoader.luau
+++ b/src/createModuleLoader.luau
@@ -12,15 +12,26 @@ local resolveInstancePath = require("@root/resolveInstancePath")
 local setModuleSource = require("@root/setModuleSource")
 local types = require("@root/types")
 
+local requireAny = require :: any
+
 type LoadedModule = types.LoadedModule
 type ModuleLoader = types.ModuleLoader
 type ModuleRegistry = types.ModuleRegistry
 type ModuleFunction = types.ModuleFunction
 
 local function getModuleFunction(moduleScript: ModuleScript, params: { string }?): ModuleFunction
-	local tmpScript = Instance.new("ModuleScript")
-	tmpScript.Name = moduleScript.Name
-	tmpScript.Archivable = false
+	local nativeRequire: ModuleFunction = function()
+		return requireAny(moduleScript)
+	end
+
+	-- If we can't read the source there's nothing we can really do with this
+	-- module, so skip straight to native require. We mainly hit this case with
+	-- Flipbook's embedded flow that runs off the client in userspace, so our
+	-- options are slim.
+	local source = getModuleSource(moduleScript)
+	if not source then
+		return nativeRequire
+	end
 
 	local mergedParams = { "script", "require" }
 	if params then
@@ -28,8 +39,6 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 			table.insert(mergedParams, param)
 		end
 	end
-
-	local source = getModuleSource(moduleScript)
 
 	-- This all gets collapsed onto a single line so we retain line numbers of
 	-- the source.
@@ -57,32 +66,46 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 		"end",
 	}, " ")
 
-	setModuleSource(tmpScript, newSource)
+	local chunkName = moduleScript:GetFullName()
 
-	local createModuleFunction
-	local ok, err = xpcall(function()
-		createModuleFunction = (require :: any)(tmpScript)
-	end, debug.traceback)
+	-- A nil chunkFn with a message means a real syntax error (surface it); a
+	-- nil chunkFn with no message means loadstring is disabled (fall through).
+	local chunkFn, syntaxErrorMessage = compileWithLoadstring(newSource, chunkName)
+
+	if chunkFn then
+		local ok, result = xpcall(chunkFn, debug.traceback)
+		if ok and typeof(result) == "function" then
+			return result :: ModuleFunction
+		end
+		error(result, 0)
+	end
+
+	if syntaxErrorMessage then
+		error(syntaxErrorMessage, 0)
+	end
+
+	local tmpScript = Instance.new("ModuleScript")
+	tmpScript.Name = moduleScript.Name
+	tmpScript.Archivable = false
+
+	if setModuleSource(tmpScript, newSource) then
+		local moduleFunction
+		local ok, err = xpcall(function()
+			moduleFunction = requireAny(tmpScript)
+		end, debug.traceback)
+
+		tmpScript:Destroy()
+
+		if ok then
+			return moduleFunction
+		end
+
+		error(err, 0)
+	end
 
 	tmpScript:Destroy()
 
-	if not ok then
-		local errorMessage: string?
-		local _, syntaxErrorMessage = compileWithLoadstring(newSource, moduleScript:GetFullName())
-
-		if syntaxErrorMessage then
-			errorMessage = syntaxErrorMessage
-		else
-			errorMessage = err
-		end
-
-		error(errorMessage, 0)
-	end
-
-	return function(...)
-		local moduleFunction = createModuleFunction(...)
-		return moduleFunction()
-	end
+	return nativeRequire
 end
 
 local function weak<K, V>(tab: { [K]: V }): { [K]: V }
@@ -152,6 +175,8 @@ function createModuleLoader(): ModuleLoader
 				-- Notice how the arguments here map to the params in
 				-- `getModuleFunction`, which in this case is `script`,
 				-- `require`, and `_G` in the context of the loaded module.
+				-- In the embedded/client flow where we fall back to native
+				-- require, moduleFunction is a wrapper that ignores these args.
 				exports = table.pack(moduleFunction(resolvedModule, childRequire, globals))
 			end, debug.traceback)
 

--- a/src/createModuleLoader.luau
+++ b/src/createModuleLoader.luau
@@ -50,7 +50,6 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 	-- If we can't read the source (e.g. client userspace), fall back to native
 	-- require and skip the rest.
 	if not source then
-		tmpScript:Destroy()
 		return nativeRequire
 	end
 
@@ -86,7 +85,6 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 	local chunkFn, syntaxErrorMessage = compileWithLoadstring(newSource, moduleScript:GetFullName())
 
 	if chunkFn then
-		tmpScript:Destroy()
 		local ok, result = xpcall(chunkFn, debug.traceback)
 		if ok and typeof(result) == "function" then
 			return wrapCompiled(result)
@@ -95,12 +93,10 @@ local function getModuleFunction(moduleScript: ModuleScript, params: { string }?
 	end
 
 	if syntaxErrorMessage then
-		tmpScript:Destroy()
 		error(syntaxErrorMessage, 0)
 	end
 
 	if not setModuleSource(tmpScript, newSource) then
-		tmpScript:Destroy()
 		return nativeRequire
 	end
 

--- a/src/getModuleSource.luau
+++ b/src/getModuleSource.luau
@@ -3,16 +3,21 @@ pcall(function()
 	ScriptEditorService = game:GetService("ScriptEditorService")
 end)
 
-local function getModuleSource(moduleScript: ModuleScript): string
+local function getModuleSource(moduleScript: ModuleScript): string?
 	if ScriptEditorService then
-		return ScriptEditorService:GetEditorSource(moduleScript)
+		local ok, result = pcall(function()
+			return ScriptEditorService:GetEditorSource(moduleScript)
+		end)
+		if ok then
+			return result
+		end
 	end
 
 	local success, result = pcall(function()
 		return moduleScript.Source
 	end)
 
-	return if success then result else ""
+	return if success then result else nil
 end
 
 return getModuleSource

--- a/src/setModuleSource.luau
+++ b/src/setModuleSource.luau
@@ -3,16 +3,23 @@ pcall(function()
 	ScriptEditorService = game:GetService("ScriptEditorService")
 end)
 
-local function setModuleSource(moduleScript: ModuleScript, newSource: string)
+local function setModuleSource(moduleScript: ModuleScript, newSource: string): boolean
 	if ScriptEditorService then
-		ScriptEditorService:UpdateSourceAsync(moduleScript, function()
-			return newSource
+		local ok = pcall(function()
+			ScriptEditorService:UpdateSourceAsync(moduleScript, function()
+				return newSource
+			end)
 		end)
-	else
-		pcall(function()
-			moduleScript.Source = newSource
-		end)
+		if ok then
+			return true
+		end
 	end
+
+	local success = pcall(function()
+		moduleScript.Source = newSource
+	end)
+
+	return success
 end
 
 return setModuleSource


### PR DESCRIPTION
## Problem

When a module's `Source` can't be read and `loadstring` is unavailable (like Flipbook's embedded flow that runs off the client in userspace) the loader has no way to evaluate modules.

## Solution

We now have error handling along the way for `Source` read/writes or ScriptEditorService usage, and if the loader determines none of these methods are working to read the source it will fallback to plain old `require`.

This should work well enough as a last resort, especially for Flipbook's embedded flow which has no expectation of modules being edited, so there's nothing to live-reload.

## Testing

Verified in practice through Flipbook's embedded flow. It's the reason the [Flipbook Stories experience](https://www.roblox.com/games/139676401890813/Flipbook-Stories) works at all!