### PR TITLE
Mirror version to loom.config.luau in release workflow

### DIFF
--- a/changewrite.toml
+++ b/changewrite.toml
@@ -2,4 +2,5 @@
 current = "0.11.0"
 mirror = [
   { file = "wally.toml" },
+  { file = "loom.config.luau" },
 ]

--- a/loom.config.luau
+++ b/loom.config.luau
@@ -1,7 +1,7 @@
 return {
 	package = {
 		name = "ModuleLoader",
-		version = "0.10.0",
+		version = "0.11.0",
 		dependencies = {
 			["flipbook-batteries"] = {
 				rev = "v0.10.1",


### PR DESCRIPTION
Add `loom.config.luau` to the changewrite mirror list so the release workflow bumps its version automatically alongside `wally.toml`.

Also syncs `loom.config.luau` to the current version (0.11.0) — it was one release behind at 0.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)