### PR TITLE
Harden ModuleLoader test suite ahead of refactor

### DIFF
--- a/src/createModuleLoader.spec.luau
+++ b/src/createModuleLoader.spec.luau
@@ -140,6 +140,30 @@ describe("loadedModuleChanged", function()
 
 		expect(count).toBe(1)
 	end)
+
+	test("stops firing after the cache is cleared", function()
+		local mockModuleInstance = Instance.new("ModuleScript")
+		mockModuleInstance.Source = "return nil"
+		mockModuleInstance.Parent = game
+
+		loader.require(mockModuleInstance)
+
+		-- clear() disconnects the change listeners set up during require, so a
+		-- later change to a no-longer-tracked module must not fire the signal.
+		loader.clear()
+
+		local firedAfterClear = false
+		loader.loadedModuleChanged:Connect(function()
+			firedAfterClear = true
+		end)
+
+		mockModuleInstance.Source = "return true"
+		task.wait()
+
+		expect(firedAfterClear).toBe(false)
+
+		mockModuleInstance:Destroy()
+	end)
 end)
 
 describe("cache", function()
@@ -164,15 +188,72 @@ describe("cache", function()
 		expect(first).toBe(true)
 		expect(second).toBe(false)
 	end)
+
+	test("short-circuits execution so a cached module's source never runs", function()
+		local moduleScript = Instance.new("ModuleScript")
+		-- If the cache were bypassed, requiring would execute this and throw.
+		moduleScript.Source = "error('cached module should not be executed')"
+
+		loader.cache(moduleScript, "cached")
+
+		expect(loader.require(moduleScript)).toBe("cached")
+	end)
 end)
 
 describe("require", function()
-	test("adds the module to the cache", function()
-		local mockModuleInstance = Instance.new("ModuleScript")
-		mockModuleInstance.Source = "return nil"
+	test("returns the identical cached result on a repeated require of the same module", function()
+		local moduleScript = Instance.new("ModuleScript")
+		-- A fresh table is allocated each time the source runs, so table
+		-- identity across two requires proves the cached value was returned
+		-- rather than the source being executed a second time.
+		moduleScript.Source = "return {}"
 
-		loader.require(mockModuleInstance)
-		expect(moduleRegistry.getByInstance(mockModuleInstance)).toBeDefined()
+		local first = loader.require(moduleScript)
+		local second = loader.require(moduleScript)
+
+		expect(first).toBe(second)
+	end)
+
+	test("returns every value a module returns", function()
+		local moduleScript = Instance.new("ModuleScript")
+		moduleScript.Source = "return 1, 2, 3"
+
+		local a, b, c = loader.require(moduleScript)
+
+		expect(a).toBe(1)
+		expect(b).toBe(2)
+		expect(c).toBe(3)
+	end)
+
+	test("exposes the module itself to its source as the `script` global", function()
+		local moduleScript = Instance.new("ModuleScript")
+		moduleScript.Source = "return script"
+
+		expect(loader.require(moduleScript)).toBe(moduleScript)
+	end)
+
+	test("propagates a runtime error raised while a module loads", function()
+		local moduleScript = Instance.new("ModuleScript")
+		moduleScript.Source = "error('boom')"
+
+		expect(function()
+			loader.require(moduleScript)
+		end).toThrow("boom")
+	end)
+
+	test("does not cache a module that errored, so a later require can succeed", function()
+		local moduleScript = Instance.new("ModuleScript")
+		moduleScript.Source = "error('boom')"
+
+		expect(function()
+			loader.require(moduleScript)
+		end).toThrow("boom")
+
+		-- A failed load must not leave a poisoned (never-loaded) entry behind.
+		-- With the source fixed, requiring again re-runs it without a clear().
+		moduleScript.Source = "return true"
+
+		expect(loader.require(moduleScript)).toBe(true)
 	end)
 
 	test("returns cached results", function()
@@ -591,28 +672,29 @@ describe("require", function()
 			tree = createModuleTest(({
 				Folder = {
 					Module3 = [[
-						return {}
+						return "resolved"
 					]],
 					Folder = {
 						Module2 = [[
-							require("../Module3")
-							return {}
+							-- Leading `../` ascends two levels to the outer
+							-- Folder, from which Module3 is a child.
+							return require("../Module3")
 						]],
 					},
 				},
 				Module1 = [[
-					require("./Folder/Folder/Module2")
-					return {}
+					return require("./Folder/Folder/Module2")
 				]],
 				Consumer = [[
-					require("./Module1")
-					return nil
+					return require("./Module1")
 				]],
 			} :: any) :: ModuleTestTree)
 
 			local consumer = tree:QueryDescendants("#Consumer")[1] :: ModuleScript
 
-			loader.require(consumer)
+			-- The sentinel threads back through every relative hop, so a
+			-- misresolved path would surface as a require error or wrong value.
+			expect(loader.require(consumer)).toBe("resolved")
 		end)
 	end)
 end)

--- a/src/createModuleRegistry.spec.luau
+++ b/src/createModuleRegistry.spec.luau
@@ -1,62 +1,159 @@
 local JestGlobals = require("@pkg/JestGlobals")
 local test = JestGlobals.test
 local expect = JestGlobals.expect
+local describe = JestGlobals.describe
 
 local createModuleRegistry = require("./createModuleRegistry")
 
-test("adds a module to the registry", function()
-	local registry = createModuleRegistry()
-
+local function newModule(name: string?): ModuleScript
 	local moduleScript = Instance.new("ModuleScript")
-	local mockLoadedModule = {} :: any
-
-	registry.add(moduleScript, mockLoadedModule)
-
-	expect(registry.getByInstance(moduleScript)).toBeDefined()
-	expect(registry.getByFullName(moduleScript:GetFullName())).toBeDefined()
-end)
-
-test("removes a module from the registry", function()
-	local registry = createModuleRegistry()
-
-	local moduleScript = Instance.new("ModuleScript")
-	local mockLoadedModule = {} :: any
-
-	registry.add(moduleScript, mockLoadedModule)
-
-	expect(registry.getByInstance(moduleScript)).toBeDefined()
-	expect(registry.getByFullName(moduleScript:GetFullName())).toBeDefined()
-
-	registry.remove(moduleScript)
-
-	expect(registry.getByInstance(moduleScript)).toBeUndefined()
-	expect(registry.getByFullName(moduleScript:GetFullName())).toBeUndefined()
-end)
-
-test("reset the registry", function()
-	local registry = createModuleRegistry()
-
-	local folder = Instance.new("Folder")
-
-	for _, name in { "ModuleA", "ModuleB", "ModuleC" } do
-		local moduleScript = Instance.new("ModuleScript")
+	if name then
 		moduleScript.Name = name
-		moduleScript.Parent = folder
-
-		local mockLoadedModule = {} :: any
-
-		registry.add(moduleScript, mockLoadedModule)
 	end
+	return moduleScript
+end
 
-	for _, moduleScript in folder:GetChildren() do
-		expect(registry.getByInstance(moduleScript :: ModuleScript)).toBeDefined()
-		expect(registry.getByFullName(moduleScript:GetFullName())).toBeDefined()
-	end
+describe("add / getByInstance / getByFullName", function()
+	test("stores the exact LoadedModule that was added, keyed by Instance", function()
+		local registry = createModuleRegistry()
+		local moduleScript = newModule()
+		local loadedModule = {} :: any
 
-	registry.reset()
+		registry.add(moduleScript, loadedModule)
 
-	for _, moduleScript in folder:GetChildren() do
-		expect(registry.getByInstance(moduleScript :: ModuleScript)).toBeUndefined()
-		expect(registry.getByFullName(moduleScript:GetFullName())).toBeUndefined()
-	end
+		expect(registry.getByInstance(moduleScript)).toBe(loadedModule)
+	end)
+
+	test("indexes the same LoadedModule under the Instance's full name", function()
+		local registry = createModuleRegistry()
+		local moduleScript = newModule()
+		local loadedModule = {} :: any
+
+		registry.add(moduleScript, loadedModule)
+
+		-- The value reachable by full name must be the very same table reachable
+		-- by Instance, not merely a truthy entry.
+		expect(registry.getByFullName(moduleScript:GetFullName())).toBe(loadedModule)
+		expect(registry.getByFullName(moduleScript:GetFullName())).toBe(registry.getByInstance(moduleScript))
+	end)
+
+	test("overwrites the previous entry when the same Instance is added twice", function()
+		local registry = createModuleRegistry()
+		local moduleScript = newModule()
+		local first = {} :: any
+		local second = {} :: any
+
+		registry.add(moduleScript, first)
+		registry.add(moduleScript, second)
+
+		expect(registry.getByInstance(moduleScript)).toBe(second)
+		expect(registry.getByFullName(moduleScript:GetFullName())).toBe(second)
+	end)
+
+	test("returns nil for an Instance that was never added", function()
+		local registry = createModuleRegistry()
+
+		expect(registry.getByInstance(newModule())).toBeNil()
+	end)
+
+	test("returns nil for a full name that was never added", function()
+		local registry = createModuleRegistry()
+
+		expect(registry.getByFullName("Game.Nonexistent")).toBeNil()
+	end)
+end)
+
+describe("remove", function()
+	test("clears both the Instance and full-name indexes for a module", function()
+		local registry = createModuleRegistry()
+		local moduleScript = newModule()
+
+		registry.add(moduleScript, {} :: any)
+		registry.remove(moduleScript)
+
+		expect(registry.getByInstance(moduleScript)).toBeNil()
+		expect(registry.getByFullName(moduleScript:GetFullName())).toBeNil()
+	end)
+
+	test("leaves other modules intact", function()
+		local registry = createModuleRegistry()
+		local kept = newModule("Kept")
+		local removed = newModule("Removed")
+		local keptModule = {} :: any
+
+		registry.add(kept, keptModule)
+		registry.add(removed, {} :: any)
+
+		registry.remove(removed)
+
+		expect(registry.getByInstance(kept)).toBe(keptModule)
+		expect(registry.getByInstance(removed)).toBeNil()
+	end)
+
+	test("is a no-op for a module that was never added", function()
+		local registry = createModuleRegistry()
+
+		expect(function()
+			registry.remove(newModule())
+		end).never.toThrow()
+	end)
+end)
+
+describe("getAllModules", function()
+	test("returns an empty list before anything is added", function()
+		local registry = createModuleRegistry()
+
+		expect(registry.getAllModules()).toEqual({})
+	end)
+
+	test("returns every added module Instance", function()
+		local registry = createModuleRegistry()
+		local moduleA = newModule("ModuleA")
+		local moduleB = newModule("ModuleB")
+		local moduleC = newModule("ModuleC")
+
+		registry.add(moduleA, {} :: any)
+		registry.add(moduleB, {} :: any)
+		registry.add(moduleC, {} :: any)
+
+		local all = registry.getAllModules()
+
+		expect(#all).toBe(3)
+		expect(all).toContain(moduleA)
+		expect(all).toContain(moduleB)
+		expect(all).toContain(moduleC)
+	end)
+
+	test("stops reporting a module once it is removed", function()
+		local registry = createModuleRegistry()
+		local moduleScript = newModule()
+
+		registry.add(moduleScript, {} :: any)
+		registry.remove(moduleScript)
+
+		expect(registry.getAllModules()).never.toContain(moduleScript)
+	end)
+end)
+
+describe("reset", function()
+	test("clears every module from both indexes", function()
+		local registry = createModuleRegistry()
+		local folder = Instance.new("Folder")
+
+		local modules = {}
+		for _, name in { "ModuleA", "ModuleB", "ModuleC" } do
+			local moduleScript = newModule(name)
+			moduleScript.Parent = folder
+			registry.add(moduleScript, {} :: any)
+			table.insert(modules, moduleScript)
+		end
+
+		registry.reset()
+
+		expect(registry.getAllModules()).toEqual({})
+		for _, moduleScript in modules do
+			expect(registry.getByInstance(moduleScript)).toBeNil()
+			expect(registry.getByFullName(moduleScript:GetFullName())).toBeNil()
+		end
+	end)
 end)

--- a/src/resolveInstancePath.spec.luau
+++ b/src/resolveInstancePath.spec.luau
@@ -3,76 +3,135 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local JestGlobals = require("@pkg/JestGlobals")
 local test = JestGlobals.test
 local expect = JestGlobals.expect
+local describe = JestGlobals.describe
 
 local resolveInstancePath = require("./resolveInstancePath")
 
-test("supports @game alias", function()
-	local moduleScript = Instance.new("ModuleScript")
-	moduleScript.Parent = ReplicatedStorage
+describe("@game alias", function()
+	test("resolves a descendant path under game", function()
+		local moduleScript = Instance.new("ModuleScript")
+		moduleScript.Parent = ReplicatedStorage
 
-	expect(resolveInstancePath(moduleScript, "@game/ReplicatedStorage/ModuleScript")).toBe(moduleScript)
+		expect(resolveInstancePath(moduleScript, "@game/ReplicatedStorage/ModuleScript")).toBe(moduleScript)
 
-	moduleScript:Destroy()
+		moduleScript:Destroy()
+	end)
+
+	test("resolves to game itself when the path is only the alias", function()
+		local moduleScript = Instance.new("ModuleScript")
+
+		expect(resolveInstancePath(moduleScript, "@game")).toBe(game)
+	end)
 end)
 
-test("supports @self alias", function()
-	local root = Instance.new("ModuleScript")
+describe("@self alias", function()
+	test("resolves a child of the module the path is relative to", function()
+		local root = Instance.new("ModuleScript")
 
-	local child = Instance.new("ModuleScript")
-	child.Parent = root
+		local child = Instance.new("ModuleScript")
+		child.Parent = root
 
-	expect(resolveInstancePath(root, "@self/ModuleScript")).toBe(child)
+		expect(resolveInstancePath(root, "@self/ModuleScript")).toBe(child)
+	end)
+
+	test("resolves to the module itself when the path is only the alias", function()
+		local root = Instance.new("ModuleScript")
+
+		expect(resolveInstancePath(root, "@self")).toBe(root)
+	end)
+
+	test("resolves a multi-segment descendant path", function()
+		local root = Instance.new("ModuleScript")
+		root.Name = "Root"
+
+		local folder = Instance.new("Folder")
+		folder.Name = "Nested"
+		folder.Parent = root
+
+		local leaf = Instance.new("ModuleScript")
+		leaf.Name = "Leaf"
+		leaf.Parent = folder
+
+		expect(resolveInstancePath(root, "@self/Nested/Leaf")).toBe(leaf)
+	end)
 end)
 
-test("supports ascending with ./ and ../", function()
-	local root = Instance.new("ModuleScript")
-	root.Name = "Root"
+describe("relative ascent", function()
+	local root, child1, child2, descendant
 
-	local child1 = Instance.new("ModuleScript")
-	child1.Name = "Child1"
-	child1.Parent = root
+	local function buildTree()
+		root = Instance.new("ModuleScript")
+		root.Name = "Root"
 
-	local child2 = Instance.new("ModuleScript")
-	child2.Name = "Child2"
-	child2.Parent = child1
+		child1 = Instance.new("ModuleScript")
+		child1.Name = "Child1"
+		child1.Parent = root
 
-	local descendant = Instance.new("ModuleScript")
-	descendant.Name = "Descendant"
-	descendant.Parent = child2
+		child2 = Instance.new("ModuleScript")
+		child2.Name = "Child2"
+		child2.Parent = child1
 
-	expect(resolveInstancePath(descendant, "./")).toBe(child2)
-	expect(resolveInstancePath(descendant, "../")).toBe(child1)
-	expect(resolveInstancePath(descendant, "../../")).toBe(root)
+		descendant = Instance.new("ModuleScript")
+		descendant.Name = "Descendant"
+		descendant.Parent = child2
+	end
+
+	test("a leading ./ ascends one level to the module's parent", function()
+		buildTree()
+		expect(resolveInstancePath(descendant, "./")).toBe(child2)
+	end)
+
+	test("a leading ../ ascends two levels", function()
+		buildTree()
+		expect(resolveInstancePath(descendant, "../")).toBe(child1)
+	end)
+
+	test("each additional ../ after the first ascends one more level", function()
+		buildTree()
+		expect(resolveInstancePath(descendant, "../../")).toBe(root)
+	end)
+
+	test("can descend into a sibling after ascending", function()
+		buildTree()
+		local sibling = Instance.new("ModuleScript")
+		sibling.Name = "Sibling"
+		sibling.Parent = child1
+
+		-- ../ lands on child1 (two levels up), then Sibling descends into it.
+		expect(resolveInstancePath(descendant, "../Sibling")).toBe(sibling)
+	end)
 end)
 
-test("throws if the path doesn't resolve to an instance", function()
-	local moduleScript = Instance.new("ModuleScript")
+describe("errors", function()
+	test("throws naming the unresolved segment when a child is missing", function()
+		local moduleScript = Instance.new("ModuleScript")
 
-	expect(function()
-		resolveInstancePath(moduleScript, "@self/DoesNotExist")
-	end).toThrow()
-end)
+		expect(function()
+			resolveInstancePath(moduleScript, "@self/DoesNotExist")
+		end).toThrow("DoesNotExist")
+	end)
 
-test("throws for absolute paths", function()
-	local moduleScript = Instance.new("ModuleScript")
+	test("throws for absolute paths beginning with '/'", function()
+		local moduleScript = Instance.new("ModuleScript")
 
-	expect(function()
-		resolveInstancePath(moduleScript, "/Foo/Bar")
-	end).toThrow("paths beginning with '/' are not supported in sandboxed string requires")
-end)
+		expect(function()
+			resolveInstancePath(moduleScript, "/Foo/Bar")
+		end).toThrow("paths beginning with '/' are not supported in sandboxed string requires")
+	end)
 
-test("throws when including '..' anywhere after the first part of the path", function()
-	local root = Instance.new("ModuleScript")
+	test("throws when '..' appears after the beginning of the path", function()
+		local root = Instance.new("ModuleScript")
 
-	local child = Instance.new("ModuleScript")
-	child.Name = "Child"
-	child.Parent = root
+		local child = Instance.new("ModuleScript")
+		child.Name = "Child"
+		child.Parent = root
 
-	local sibling = Instance.new("ModuleScript")
-	sibling.Name = "Sibling"
-	sibling.Parent = root
+		local sibling = Instance.new("ModuleScript")
+		sibling.Name = "Sibling"
+		sibling.Parent = root
 
-	expect(function()
-		resolveInstancePath(root, "@self/Child/../Sibling")
-	end).toThrow("paths including '..' after the beginning are not supported in sandboxed string requires")
+		expect(function()
+			resolveInstancePath(root, "@self/Child/../Sibling")
+		end).toThrow("paths including '..' after the beginning are not supported in sandboxed string requires")
+	end)
 end)


### PR DESCRIPTION
## Problem

Ahead of an extensive ModuleLoader refactor, the existing specs aren't a tight enough safety net. Several tests optimize for green rather than for *specifying intended behavior*: vacuous `toBeDefined()` / `toBeUndefined()` checks where a concrete value is assertable, a `resolveInstancePath` error test that only asserts *that* it throws, and — most importantly — a `require` test for relative paths that **asserts nothing at all**. Gaps in error/edge coverage mean a refactor could regress silently.

## Solution

Harden the three specs so each test encodes a claim about the module's contract and can actually fail when the code is wrong. Applied the discipline from the pending [`write-flipbook-tests`](https://github.com/flipbook-labs/flipbook/pull/606) skill: test the intended contract (not current behavior), no vacuous or tautological assertions, error/edge paths as first-class, and a **red-first gate** — every new or changed assertion was seen red via a hand-rolled mutation (flip a branch, nil a field, swap a return) and confirmed to fail *for its own reason* before landing.

**`createModuleRegistry.spec`**
- Replace `toBeDefined()`/`toBeUndefined()` with concrete assertions on the exact stored `LoadedModule`, and assert the instance and full-name indexes stay in sync.
- Add previously untested edges: unknown-key lookups return `nil`, `add` overwrites a re-added module, `remove` is a no-op for unknown input, `getAllModules` reflects adds/removes, and `reset` clears both indexes.

**`resolveInstancePath.spec`**
- Match the message on the unresolved-segment throw instead of a bare `toThrow()`.
- Add bare-`@self`/`@game` resolution, multi-segment descent, and descend-after-ascend.

**`createModuleLoader.spec`**
- Give the `supports relative paths` test a sentinel it must actually return (it previously asserted nothing).
- Replace the `toBeDefined()` cache check with an observable identity assertion on a repeated require.
- Add coverage for multi-value returns, the `script` global, runtime-error propagation, error eviction + recovery, `cache` short-circuiting execution, and `loadedModuleChanged` going silent after `clear()`.

No production code changes — specs only. Test count goes from 35 to 56.

## Testing

- `lute run lint` and `lute run analyze` pass.
- `lute run test` — **56 passed** (was 35).
- Red-first gate: every new/changed assertion was seen fail against a deliberate mutation of the code under test (e.g. disabling the registry's full-name index, returning a fresh table from the cache branch, passing the wrong `script` arg, skipping `clear()`'s disconnect loop, genericizing the `resolveInstancePath` guard messages), then confirmed green once reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)