### PR TITLE
Upgrade FlipbookBatteries to v0.12.0, Lute to nightly.20260701 (+ darklua, luau-lsp)

### DIFF
--- a/.changes/upgrade-lute-and-batteries.md
+++ b/.changes/upgrade-lute-and-batteries.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Dependencies
+---
+
+Upgrade FlipbookBatteries `v0.10.1` → `v0.12.0`, Lute `v1.0.1-nightly.20260604` → `v1.0.1-nightly.20260701`, darklua `0.18.0` → `0.19.0`, and luau-lsp `1.68.0` → `1.68.1`.

--- a/.lute/analyze.luau
+++ b/.lute/analyze.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.12.0")
 local path = require("@std/path")
 local system = require("@std/system")
 

--- a/.lute/build.luau
+++ b/.lute/build.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.12.0")
 local cli = require("@scripts/batteries/cli")
 local fs = require("@std/fs")
 

--- a/.lute/install.luau
+++ b/.lute/install.luau
@@ -12,7 +12,7 @@ do
 end
 
 do
-	local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.10.1")
+	local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.12.0")
 
 	local run = FlipbookBatteries.run
 

--- a/.lute/lint.luau
+++ b/.lute/lint.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.12.0")
 local path = require("@std/path")
 local process = require("@std/process")
 

--- a/.lute/test.luau
+++ b/.lute/test.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.12.0")
 local process = require("@std/process")
 local system = require("@std/system")
 

--- a/.lute/try-in-flipbook.luau
+++ b/.lute/try-in-flipbook.luau
@@ -4,7 +4,7 @@
 	path/git dependencies, so we have to make our own shim.
 ]]
 
-local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.12.0")
 local fs = require("@std/fs")
 local path = require("@std/path")
 

--- a/.lute/try-in-storyteller.luau
+++ b/.lute/try-in-storyteller.luau
@@ -4,7 +4,7 @@
 	path/git dependencies, so we have to make our own shim.
 ]]
 
-local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/flipbook-batteries@v0.12.0")
 local fs = require("@std/fs")
 local path = require("@std/path")
 

--- a/loom.config.luau
+++ b/loom.config.luau
@@ -4,7 +4,7 @@ return {
 		version = "0.11.0",
 		dependencies = {
 			["flipbook-batteries"] = {
-				rev = "v0.10.1",
+				rev = "v0.12.0",
 				sourceKind = "github",
 				source = "https://github.com/flipbook-labs/flipbook-batteries",
 			},

--- a/rokit.toml
+++ b/rokit.toml
@@ -4,9 +4,9 @@
 # New tools can be added by running `rokit add <tool>` in a terminal.
 
 [tools]
-darklua = "seaofvoices/darklua@0.18.0"
-luau-lsp = "JohnnyMorganz/luau-lsp@1.68.0"
-lute = "luau-lang/lute@1.0.1-nightly.20260604"
+darklua = "seaofvoices/darklua@0.19.0"
+luau-lsp = "JohnnyMorganz/luau-lsp@1.68.1"
+lute = "luau-lang/lute@1.0.1-nightly.20260701"
 moonwave-extractor = "evaera/moonwave@1.4.2"
 rocale = "Roblox/rocale-cli@0.1.3"
 rojo = "rojo-rbx/rojo@7.6.1"


### PR DESCRIPTION
## Problem

`module-loader` pins FlipbookBatteries `v0.10.1` and lags on toolchain versions (Lute `20260604`, darklua `0.18.0`, luau-lsp `1.68.0`). FlipbookBatteries `v0.12.0` pins Lute `v1.0.1-nightly.20260701`; module-loader consumes Lute transitively through batteries, so bumping batteries pulls the newer Lute — the Rokit `lute` tool moves to match.

## Solution

- FlipbookBatteries `v0.10.1` → `v0.12.0` in `loom.config.luau` and the `require("@luaupkg/flipbook-batteries@…")` paths across the `.lute/` scripts (`analyze`, `build`, `lint`, `test`, `install`, `try-in-flipbook`, `try-in-storyteller`).
- Rokit: Lute `20260604` → `20260701`, darklua `0.18.0` → `0.19.0`, luau-lsp `1.68.0` → `1.68.1` (highest-in-use across the fleet).
- Add a `.changes/` entry (Dependencies, patch bump).

## Verification

Local run on the new pins:

| Step | Result |
|---|---|
| `lute run install` | ✅ loom + `wally install` + rojo sourcemap resolve `flipbook-batteries@v0.12.0` |
| `lute run build --channel prod` | ✅ darklua + `rojo build` produce the `ModuleLoader` rbxm |
| `lute run lint` | ✅ selene + stylua, 0 errors / 0 warnings |
| `lute run analyze` | ✅ luau-lsp across `.lute` and src |
| `lute run test` | ⚠️ requires `ROBLOX_API_KEY` not available locally — CI supplies it; unrelated to this bump |

> Part of the fleet-wide Lute `20260701` bump; depends on FlipbookBatteries `v0.12.0` (already released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)