### PR TITLE
Source ROBLOX_API_KEY from 1Password in tests job

### DIFF
--- a/.changes/ci-roblox-key-from-1password.md
+++ b/.changes/ci-roblox-key-from-1password.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Changes
+---
+
+CI now sources the Roblox Open Cloud API key from the shared Flipbook 1Password vault at run time via `load-secrets-action`, rather than from a repo-level GitHub Actions secret. No effect on the published package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,13 @@ jobs:
       - name: Install packages
         run: lute run install
 
+      - name: Load secrets from 1Password
+        uses: 1Password/load-secrets-action@v3
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ROBLOX_API_KEY: op://Flipbook/Flipbook CI (Open Cloud)/password
+
       - name: Run tests
-        run: lute run test --apiKey ${{ secrets.ROBLOX_API_KEY }}
+        run: lute run test --apiKey "$ROBLOX_API_KEY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          ROBLOX_API_KEY: op://Flipbook/Flipbook CI (Open Cloud)/password
+          ROBLOX_API_KEY: op://Flipbook/Strict Sandbox API Key/password
 
       - name: Run tests
         run: lute run test --apiKey "$ROBLOX_API_KEY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,9 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          ROBLOX_API_KEY: op://Flipbook/Flipbook CI (Open Cloud)/password
+          # Item "Flipbook CI (Open Cloud)" — referenced by ID because its
+          # parenthesized title breaks op:// reference parsing.
+          ROBLOX_API_KEY: op://Flipbook/7c2b4vowqat6feao5x3nm7cwom/password
 
       - name: Run tests
         run: lute run test --apiKey "$ROBLOX_API_KEY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          ROBLOX_API_KEY: op://Flipbook/Strict Sandbox API Key/password
+          ROBLOX_API_KEY: op://Flipbook/Flipbook CI (Open Cloud)/password
 
       - name: Run tests
         run: lute run test --apiKey "$ROBLOX_API_KEY"


### PR DESCRIPTION
## Problem

The `tests` job reads `ROBLOX_API_KEY` from a repo-level GitHub Actions secret. The same Roblox Open Cloud key is pasted independently into several flipbook-labs repos, so rotating it means editing each repo's Actions settings, and there's no single source of truth.

## Solution

Source the key at run time from the shared **Flipbook** 1Password vault via [`load-secrets-action`](https://github.com/1Password/load-secrets-action), authed by the org-level `OP_SERVICE_ACCOUNT_TOKEN`:

```yaml
- name: Load secrets from 1Password
  uses: 1Password/load-secrets-action@v3
  with:
    export-env: true
  env:
    OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
    ROBLOX_API_KEY: op://Flipbook/Flipbook CI (Open Cloud)/password
```

The value stays masked in logs. Now the key is rotated once in 1Password and every repo picks it up; onboarding a repo is granting vault access, not copying a secret. The repo-level `ROBLOX_API_KEY` secret can be deleted once this merges.

## Scope

This is a **pilot** for rolling the pattern across flipbook-labs. It intentionally converts only the `tests` job — the fully-unblocked path, which runs on every PR, so this PR's own green CI is the end-to-end proof.

`release.yml` (Wally token + GitHub App private key) is a deliberate **follow-up**: it needs a Wally token item created in the vault first, and its publish path only exercises on a real release.

## Verification

- [ ] `tests` job goes green here (proves `load-secrets-action` + org `OP_SERVICE_ACCOUNT_TOKEN` + the `op://Flipbook/Flipbook CI (Open Cloud)/password` reference all resolve)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)